### PR TITLE
Fix wrong environment config key

### DIFF
--- a/docs/guide/environments.md
+++ b/docs/guide/environments.md
@@ -27,7 +27,7 @@ The VS Code extension supports switching to different environments. A different 
 :::
 
 ## JSON
-Environments can be provided with setting `environmentVariables` in [.httpyac.js](/config/) . All settings with key `$shared` are shared between all environments
+Environments can be provided with setting `environment` in [.httpyac.js](/config/) . All settings with key `$shared` are shared between all environments
 
 ```json
 {

--- a/docs/guide/environments.md
+++ b/docs/guide/environments.md
@@ -27,7 +27,7 @@ The VS Code extension supports switching to different environments. A different 
 :::
 
 ## JSON
-Environments can be provided with setting `environment` in [.httpyac.js](/config/) . All settings with key `$shared` are shared between all environments
+Environments can be provided with setting `environments` in [.httpyac.js](/config/) . All settings with key `$shared` are shared between all environments
 
 ```json
 {


### PR DESCRIPTION
For me env config only worked with `environment` key (config as json). I guess `environmentVariables` is the key for VS Code.