### PR TITLE
Update CLI documentation.

### DIFF
--- a/docs/guide/installation_cli.md
+++ b/docs/guide/installation_cli.md
@@ -29,27 +29,50 @@ yarn global upgrade --latest httpyac
 ```shell
 > httpyac --help
 
-usage: httpyac <file or glob pattern> [options] 
-       --all           execute all http requests in a http file
-       --bail          stops when a test case fails
-  -e   --env           list of environments
-       --filter        filter requests output (only-failed)
-  -h   --help          help
-       --insecure      allow insecure server connections when using ssl
-  -i   --interactive   do not exit the program after request, go back to selection
-       --json          use json output
-  -l   --line          line of the http requests
-  -n   --name          name of the http requests
-       --no-color      disable color support
-  -o   --output        output format of response (short, body, headers, response, exchange, none)
-       --output-failed output format of failed response (short, body, headers, response, exchange, none)
-       --raw           prevent formatting of response body
-  -r   --repeat        repeat count for requests
-       --repeat-mode   repeat mode: sequential, parallel (default)
-  -s   --silent        log only request
-       --timeout       maximum time allowed for connections
-  -v   --verbose       make the operation more talkative
+Usage: httpyac [options] [command]
+httpYac - Quickly and easily send REST, SOAP, GraphQL and gRPC requests
+Options:
+  -V, --version                 output the version number
+  -h, --help                    display help for command
 
+Commands:
+  oauth2 [options]              generate oauth2 token
+  send [options] <fileName...>  send/ execute http files
+  help [command]                display help for command
+```
+
+```shell
+> httpyac help send
+
+Usage: httpyac send [options] <fileName...>
+
+send/ execute http files
+
+Arguments:
+  fileName                  path to file or glob pattern
+
+Options:
+  -a, --all                 execute all http requests in a http file
+  --bail                    stops when a test case fails
+  -e, --env  <env...>       list of environments
+  --filter <filter>          filter requests output (only-failed)
+  --insecure                allow insecure server connections when using ssl
+  -i --interactive          do not exit the program after request, go back to selection
+  --json                    use json output
+  -l, --line <line>         line of the http requests
+  -n, --name <name>         name of the http requests
+  --no-color                disable color support
+  -o, --output <output>     output format of response (short, body, headers, response, exchange, none)
+  --output-failed <output>  output format of failed response (short, body, headers, response, exchange, none)
+  --raw                     prevent formatting of response body
+  --quiet
+  --repeat <count>          repeat count for requests
+  --repeat-mode <mode>      repeat mode: sequential, parallel (default)
+  -s, --silent              log only request
+  --timeout <timeout>       maximum time allowed for connections
+  --var  <variables...>     list of variables
+  -v, --verbose             make the operation more talkative
+  -h, --help                display help for command
 ```
 
 ## Manual Selection


### PR DESCRIPTION
The documentation was not showing the current output from ```httpyac --help```. This patch updates the output.