### PR TITLE
Update lernwebservices.http

### DIFF
--- a/examples/api/lernwebservices.http
+++ b/examples/api/lernwebservices.http
@@ -1,14 +1,12 @@
 
-POST http://www.learnwebservices.com/services/hello
+POST https://apps.learnwebservices.com/services/hello
 Content-Type: application/xml
 
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
-  <soapenv:Header /> \
-  <soapenv:Body>
-    <SayHello xmlns="http://learnwebservices.com/services/hello"> \
-      <HelloRequest>
-        <Name>John Doe</Name>
-      </HelloRequest> \
-    </SayHello>
-  </soapenv:Body>
+   <soapenv:Header/>
+   <soapenv:Body>
+       <HelloRequest xmlns="http://learnwebservices.com/services/hello">
+          <Name>John Doe</Name>
+       </HelloRequest>
+   </soapenv:Body>
 </soapenv:Envelope>


### PR DESCRIPTION
> In version 2.0.0 the URL has changed from http://www.learnwebservices.com/services/hello?WSDL to https://apps.learnwebservices.com/services/hello?WSDL. The WSDL and the SOAP structure have been simplified, so the clients must be modified or regenerated.

Source: https://www.learnwebservices.com/