### PR TITLE
docs: allow docker alias to access "localhost"

### DIFF
--- a/docs/guide/installation_docker.md
+++ b/docs/guide/installation_docker.md
@@ -8,7 +8,7 @@ httpyac CLI provides a command line interface to execute *.http and *.rest files
 create alias for docker image
 
 ``` bash
-alias httpyac="docker run -it -v ${PWD}:/data ghcr.io/anweber/httpyac:latest"
+alias httpyac="docker run -it --rm --network=host -v ${PWD}:/data ghcr.io/anweber/httpyac:latest"
 ```
 and use it
 


### PR DESCRIPTION
`--rm` to clean container after usage
` --network=host` to allow to use `localhost` into HTTP file

Thanks for the httpyac toolset