### PR TITLE
docs: add Community Plugins section to plugin guide

### DIFF
--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -63,6 +63,16 @@ module.exports = () => {}
 ```
 
 
+## Community Plugins
+
+The following plugins are built and maintained by the httpYac community.
+
+| Plugin | Description |
+|---|---|
+| [httpyac-plugin-reporter-html](https://github.com/AbhilashBiradar/httpyac-plugin-reporter-html) | Generates a single standalone HTML report for all HTTP requests and test results |
+
+> Want to add your plugin? Open a [pull request](https://github.com/httpyac/httpyac.github.io/pulls) and add an entry to the table above.
+
 ## Parsing FlowChart
 
 ![parse flow](./parse_flow.svg)


### PR DESCRIPTION
## Summary

This PR adds a **Community Plugins** section to the Plugin Development Guide, making it easier for httpYac users to discover plugins built by the community.

### Changes

- Added a `## Community Plugins` section at the bottom of `docs/plugins/index.md`
- Added a table format for listing community plugins with name, link, and description
- Added a note inviting other plugin authors to contribute via PR

### First entry

| Plugin | Description |
|---|---|
| [httpyac-plugin-reporter-html](https://github.com/AbhilashBiradar/httpyac-plugin-reporter-html) | Generates a single standalone HTML report for all HTTP requests and test results — zero dependencies, works offline, perfect for CI/CD |

The plugin hooks into the `responseLogging` lifecycle event (after all `@assert` blocks run), collects request/response/test data across the entire run, and writes a standalone HTML file with a summary hero, color-coded request cards, collapsible panels, and client-side filter/search.

### Why this matters

Currently there is no way for httpYac users to discover community plugins through the official documentation. A community plugins section in the plugin guide is a natural home for this — similar to how Vue CLI, Vite, and other plugin-based tools surface community extensions in their docs.

---

Happy to adjust the format or location of this section based on your preferences.